### PR TITLE
Registration success toast description modified

### DIFF
--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -51,7 +51,7 @@ export default function SignUpPage() {
       router.push("/auth/signin");
       toast({
         title: "Registration Successful 🎉",
-        description: "Failed to create an account. Please try again.",
+        description: "Your account has been successfully created. Please log in to continue.",
       });
     } catch (error) {
       toast({


### PR DESCRIPTION
Fixes #13 

After successful Registration the toast description looks like this
"Your account has been successfully created. Please log in to continue."

![22 08 2024_21 28 47_REC](https://github.com/user-attachments/assets/282142f8-7e80-4fbb-9179-5c2a0f73e814)
