### PR TITLE
Toggle pw

### DIFF
--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -26,7 +26,7 @@ import {
 import { useToast } from "@/components/ui/use-toast";
 import Link from "next/link";
 import { useState } from "react";
-import loader from "lucide-react";
+import loader, { AtSign, Eye, EyeOff } from "lucide-react";
 
 const signInSchema = z.object({
   email: z.string().email("Invalid email address"),
@@ -38,6 +38,9 @@ type SignInFormData = z.infer<typeof signInSchema>;
 export default function SignInPage() {
   const { toast } = useToast();
   const [Loading, setLoading] = useState<boolean>(false);
+
+  const [showPassword, setShowPassword] = useState<boolean>(false);
+
   const form = useForm<SignInFormData>({
     resolver: zodResolver(signInSchema),
     defaultValues: {
@@ -88,13 +91,20 @@ export default function SignInPage() {
                 name="email"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel className="dark:text-white text-black">Email</FormLabel>
+                    <FormLabel className="dark:text-white text-black">
+                      Email
+                    </FormLabel>
                     <FormControl>
-                      <Input
-                        placeholder="Email"
-                        {...field}
-                        className="w-full dark:text-black"
-                      />
+                      <div className="flex items-center">
+                        <Input
+                          placeholder="Email"
+                          {...field}
+                          className="w-full dark:text-black"
+                        />
+                        <div className="ml-2 text-gray-500 focus:outline-none">
+                          <AtSign />
+                        </div>
+                      </div>
                     </FormControl>
                     <FormDescription>
                       This is the email address you will use to sign in.
@@ -110,15 +120,26 @@ export default function SignInPage() {
                   <FormItem>
                     <FormLabel className="flex justify-between">
                       <p className="dark:text-white text-black">Password</p>
-                      <Link href="/auth/forgot-password/email">Forgot Password?</Link>
-                      </FormLabel>
+                      <Link href="/auth/forgot-password/email">
+                        Forgot Password?
+                      </Link>
+                    </FormLabel>
                     <FormControl>
-                      <Input
-                        type="password"
-                        placeholder="Password"
-                        {...field}
-                        className="w-full dark:text-black"
-                      />
+                      <div className="flex items-center">
+                        <Input
+                          type={showPassword ? "text" : "password"}
+                          placeholder="Password"
+                          {...field}
+                          className="w-full dark:text-black"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => setShowPassword(!showPassword)}
+                          className="ml-2 text-gray-500 focus:outline-none"
+                        >
+                          {showPassword ? <EyeOff /> : <Eye />}
+                        </button>
+                      </div>
                     </FormControl>
                     <FormDescription>
                       Enter your password to log in.
@@ -127,7 +148,10 @@ export default function SignInPage() {
                   </FormItem>
                 )}
               />
-              <Button type="submit" className="w-full bg-[#425893] text-white hover:text-black">
+              <Button
+                type="submit"
+                className="w-full bg-[#425893] text-white hover:text-black"
+              >
                 {Loading ? <Pageloader /> : "Login"}
               </Button>
             </form>

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -27,6 +27,7 @@ import {
 import { toast } from "@/components/ui/use-toast";
 import Link from "next/link";
 import { ToastAction } from "@radix-ui/react-toast";
+import { AtSign, Eye, EyeOff } from "lucide-react";
 
 const signUpSchema = z.object({
   email: z.string().email("Invalid email address"),
@@ -40,6 +41,10 @@ type SignUpFormData = z.infer<typeof signUpSchema>;
 
 export default function SignUpPage() {
   const [Loading, setLoading] = useState<boolean>(false);
+  const [showPassword, setShowPassword] = useState<boolean>(false);
+  const [showConfirmPassword, setShowConfirmPassword] =
+    useState<boolean>(false);
+
   const form = useForm<SignUpFormData>({
     resolver: zodResolver(signUpSchema),
     defaultValues: {
@@ -53,7 +58,7 @@ export default function SignUpPage() {
 
   const onSubmit = async (data: SignUpFormData) => {
     setLoading(true);
-    console.log(data.password + " " + data.confirmpassword);
+    // console.log(data.password + " " + data.confirmpassword);
     if (data.password !== data.confirmpassword) {
       toast({
         variant: "destructive",
@@ -101,11 +106,16 @@ export default function SignUpPage() {
                       Email
                     </FormLabel>
                     <FormControl>
-                      <Input
-                        placeholder="Email"
-                        {...field}
-                        className="w-full dark:text-black"
-                      />
+                      <div className="flex items-center">
+                        <Input
+                          placeholder="Email"
+                          {...field}
+                          className="w-full dark:text-black"
+                        />
+                        <div className="ml-2 text-gray-500 focus:outline-none">
+                          <AtSign />
+                        </div>
+                      </div>
                     </FormControl>
                     <FormDescription>
                       This is the email address you will use to sign up.
@@ -123,12 +133,21 @@ export default function SignUpPage() {
                       Password
                     </FormLabel>
                     <FormControl>
-                      <Input
-                        type="password"
-                        placeholder="Password"
-                        {...field}
-                        className="w-full dark:text-black"
-                      />
+                      <div className="flex items-center">
+                        <Input
+                          type={showPassword ? "text" : "password"}
+                          placeholder="Password"
+                          {...field}
+                          className="w-full dark:text-black"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => setShowPassword(!showPassword)}
+                          className="ml-2 text-gray-500 focus:outline-none"
+                        >
+                          {showPassword ? <EyeOff /> : <Eye />}
+                        </button>
+                      </div>
                     </FormControl>
                     <FormDescription>
                       Enter a strong password for your account.
@@ -146,12 +165,23 @@ export default function SignUpPage() {
                       Confirm Password
                     </FormLabel>
                     <FormControl>
-                      <Input
-                        type="password"
-                        placeholder="Password"
-                        {...field}
-                        className="w-full dark:text-black"
-                      />
+                      <div className="flex items-center">
+                        <Input
+                          type={showConfirmPassword ? "text" : "password"}
+                          placeholder="Confirm Password"
+                          {...field}
+                          className="w-full dark:text-black"
+                        />
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setShowConfirmPassword(!showConfirmPassword)
+                          }
+                          className="ml-2 text-gray-500 focus:outline-none"
+                        >
+                          {showConfirmPassword ? <EyeOff /> : <Eye />}
+                        </button>
+                      </div>
                     </FormControl>
                     <FormDescription>
                       Confirm password by entering it again

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -31,6 +31,9 @@ import { ToastAction } from "@radix-ui/react-toast";
 const signUpSchema = z.object({
   email: z.string().email("Invalid email address"),
   password: z.string().min(6, "Password must be at least 6 characters long"),
+  confirmpassword: z
+    .string()
+    .min(6, "Password must be at least 6 characters long"),
 });
 
 type SignUpFormData = z.infer<typeof signUpSchema>;
@@ -42,6 +45,7 @@ export default function SignUpPage() {
     defaultValues: {
       email: "",
       password: "",
+      confirmpassword: "",
     },
   });
 
@@ -49,6 +53,17 @@ export default function SignUpPage() {
 
   const onSubmit = async (data: SignUpFormData) => {
     setLoading(true);
+    console.log(data.password + " " + data.confirmpassword);
+    if (data.password !== data.confirmpassword) {
+      toast({
+        variant: "destructive",
+        title: "Passwords don't match",
+        description: "check your passwords.",
+        action: <ToastAction altText="Try again">Try again</ToastAction>,
+      });
+      setLoading(false);
+      return;
+    }
     try {
       await axios.post("/api/auth/signup", data);
       router.push("/auth/signin");
@@ -82,7 +97,9 @@ export default function SignUpPage() {
                 name="email"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel className="dark:text-white text-black">Email</FormLabel>
+                    <FormLabel className="dark:text-white text-black">
+                      Email
+                    </FormLabel>
                     <FormControl>
                       <Input
                         placeholder="Email"
@@ -102,7 +119,9 @@ export default function SignUpPage() {
                 name="password"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel className="dark:text-white text-black">Password</FormLabel>
+                    <FormLabel className="dark:text-white text-black">
+                      Password
+                    </FormLabel>
                     <FormControl>
                       <Input
                         type="password"
@@ -113,6 +132,29 @@ export default function SignUpPage() {
                     </FormControl>
                     <FormDescription>
                       Enter a strong password for your account.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="confirmpassword"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="dark:text-white text-black">
+                      Confirm Password
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type="password"
+                        placeholder="Password"
+                        {...field}
+                        className="w-full dark:text-black"
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Confirm password by entering it again
                     </FormDescription>
                     <FormMessage />
                   </FormItem>

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18",
         "react-hook-form": "^7.52.2",
+        "react-hot-toast": "^2.4.1",
         "tailwind-merge": "^2.4.0",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.23.8"
@@ -2485,8 +2486,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3808,6 +3808,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -5666,6 +5675,22 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18",
     "react-hook-form": "^7.52.2",
+    "react-hot-toast": "^2.4.1",
     "tailwind-merge": "^2.4.0",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.8"


### PR DESCRIPTION
# 🚀 Pull Request

## Description
This PR introduces the **toggle password visibility** feature to the authentication form using the `lucide-react` icons for "open eye" and "closed eye". This improves the user experience by allowing users to view or hide their password during input.

## Changes Made
- Added `useState` to manage the toggle state for password visibility.
- Integrated `Eye` and `EyeOff` icons from `lucide-react` to indicate the password visibility status.
- Updated password and confirm password input fields to use the toggle logic on both login and signup pages.
- Minor styling adjustments to align the icons with the input fields.

## How it Works
- By default, the password is hidden.
- Clicking on the "eye" icon toggles between showing and hiding the password.
- Both **password** and **confirm password** fields support this feature independently.

- Fixes #124 
- Closes #124 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshot of final output/video


https://github.com/user-attachments/assets/ca9ec2f1-af3a-4f4b-a157-e0e14beed527


